### PR TITLE
Quick fix for issue #66

### DIFF
--- a/app/src/main/java/com/wirelessalien/android/moviedb/fragment/FavoriteFragment.kt
+++ b/app/src/main/java/com/wirelessalien/android/moviedb/fragment/FavoriteFragment.kt
@@ -46,11 +46,7 @@ class FavoriteFragment : BaseFragment() {
     private var mListType: String? = null
     private var visibleThreshold = 0
     private var currentPage = 0
-    private var previousTotal = 0
     private var loading = true
-    private var pastVisibleItems = 0
-    private var visibleItemCount = 0
-    private var totalItemCount = 0
     private var totalPages = 0
 
     @Volatile
@@ -94,7 +90,7 @@ class FavoriteFragment : BaseFragment() {
         mShowArrayList.clear()
         showIdSet.clear()
         mShowAdapter.notifyDataSetChanged()
-        currentPage = 1
+        currentPage = 0
         totalPages = 0
         mListType = if ("movie" == mListType) "tv" else "movie"
         loadFavoriteList(mListType, 1)
@@ -129,14 +125,9 @@ class FavoriteFragment : BaseFragment() {
         mShowView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
             override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
                 if (dy > 0 && recyclerView.scrollState != RecyclerView.SCROLL_STATE_IDLE) {
-                    visibleItemCount = mShowLinearLayoutManager.childCount
-                    totalItemCount = mShowLinearLayoutManager.itemCount
-                    pastVisibleItems = mShowLinearLayoutManager.findFirstVisibleItemPosition()
-                    if (loading && totalItemCount > previousTotal) {
-                        loading = false
-                        previousTotal = totalItemCount
-                        currentPage++
-                    }
+                    val visibleItemCount = mShowLinearLayoutManager.childCount
+                    val totalItemCount = mShowLinearLayoutManager.itemCount
+                    val pastVisibleItems = mShowLinearLayoutManager.findFirstVisibleItemPosition()
                     val threshold = if (preferences.getBoolean(SHOWS_LIST_PREFERENCE, true)) {
                         val gridSizePreference = preferences.getInt(GRID_SIZE_PREFERENCE, 3)
                         gridSizePreference * gridSizePreference
@@ -145,10 +136,9 @@ class FavoriteFragment : BaseFragment() {
                     }
                     if (!loading && visibleItemCount + pastVisibleItems + threshold >= totalItemCount) {
                         if (mShowArrayList.isNotEmpty() && hasMoreItemsToLoad()) {
-                            currentPage++
-                            loadFavoriteList(mListType, currentPage)
+                            loading = true
+                            loadFavoriteList(mListType, currentPage + 1)
                         }
-                        loading = true
                     }
                 }
             }
@@ -223,6 +213,8 @@ class FavoriteFragment : BaseFragment() {
                 mShowView.adapter = mShowAdapter
                 mShowView.scrollToPosition(position)
                 mShowListLoaded = true
+                if (reader.has("page"))
+                    currentPage = reader.getInt(("page"))
             } catch (je: JSONException) {
                 je.printStackTrace()
             }

--- a/app/src/main/java/com/wirelessalien/android/moviedb/fragment/WatchlistFragment.kt
+++ b/app/src/main/java/com/wirelessalien/android/moviedb/fragment/WatchlistFragment.kt
@@ -46,11 +46,7 @@ class WatchlistFragment : BaseFragment() {
     private var mListType: String? = null
     private var visibleThreshold = 0
     private var currentPage = 0
-    private var previousTotal = 0
     private var loading = true
-    private var pastVisibleItems = 0
-    private var visibleItemCount = 0
-    private var totalItemCount = 0
     private var totalPages = 0
 
     @Volatile
@@ -94,7 +90,7 @@ class WatchlistFragment : BaseFragment() {
         mShowArrayList.clear()
         showIdSet.clear()
         mShowAdapter.notifyDataSetChanged()
-        currentPage = 1
+        currentPage = 0
         totalPages = 0
         mListType = if ("movie" == mListType) "tv" else "movie"
         loadWatchList(mListType, 1)
@@ -129,14 +125,9 @@ class WatchlistFragment : BaseFragment() {
         mShowView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
             override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
                 if (dy > 0 && recyclerView.scrollState != RecyclerView.SCROLL_STATE_IDLE) {
-                    visibleItemCount = mShowLinearLayoutManager.childCount
-                    totalItemCount = mShowLinearLayoutManager.itemCount
-                    pastVisibleItems = mShowLinearLayoutManager.findFirstVisibleItemPosition()
-                    if (loading && totalItemCount > previousTotal) {
-                        loading = false
-                        previousTotal = totalItemCount
-                        currentPage++
-                    }
+                    val visibleItemCount = mShowLinearLayoutManager.childCount
+                    val totalItemCount = mShowLinearLayoutManager.itemCount
+                    val pastVisibleItems = mShowLinearLayoutManager.findFirstVisibleItemPosition()
                     val threshold = if (preferences.getBoolean(SHOWS_LIST_PREFERENCE, true)) {
                         val gridSizePreference = preferences.getInt(GRID_SIZE_PREFERENCE, 3)
                         gridSizePreference * gridSizePreference
@@ -145,10 +136,9 @@ class WatchlistFragment : BaseFragment() {
                     }
                     if (!loading && visibleItemCount + pastVisibleItems + threshold >= totalItemCount) {
                         if (mShowArrayList.isNotEmpty() && hasMoreItemsToLoad()) {
-                            currentPage++
-                            loadWatchList(mListType, currentPage)
+                            loading = true
+                            loadWatchList(mListType, currentPage + 1)
                         }
-                        loading = true
                     }
                 }
             }
@@ -223,6 +213,8 @@ class WatchlistFragment : BaseFragment() {
                 mShowView.adapter = mShowAdapter
                 mShowView.scrollToPosition(position)
                 mShowListLoaded = true
+                if (reader.has("page"))
+                    currentPage = reader.getInt(("page"))
             } catch (je: JSONException) {
                 je.printStackTrace()
             }


### PR DESCRIPTION
Instead of tracking `currentPage` locally, I suggest simply using the index returned by the response from TMDB. As it stands some pages may be skipped as a result of redundant increments.

This fix was created to address issue #66.