### PR TITLE
Fix TMDB rating not set when show exists in local db

### DIFF
--- a/app/src/main/java/com/wirelessalien/android/moviedb/activity/DetailActivity.kt
+++ b/app/src/main/java/com/wirelessalien/android/moviedb/activity/DetailActivity.kt
@@ -2219,7 +2219,10 @@ class DetailActivity : BaseActivity() {
 
                 // Make it possible to change the values.
                 binding.editIcon.visibility = View.VISIBLE
-            } else if (movieObject.has("vote_average") &&
+            }
+
+            // Set TMDB rating if it exists
+            if (movieObject.has("vote_average") &&
                 movieObject.getString("vote_average") != voteAverage
             ) {
                 val voteAverage = movieObject.getString("vote_average").toFloat()


### PR DESCRIPTION
When a show is saved to local db, details page no longer displays correct TMDB rating but instead it displays the default one set in activity_details.xml  (7.6/10)

I tested it with the emulator.

**Before**
![image](https://github.com/user-attachments/assets/b9500d99-ee94-4177-9036-4c118bc8729c)

**After**
![image](https://github.com/user-attachments/assets/db3d3dcc-b471-4fce-ae4a-2495c4326fb8)
